### PR TITLE
Add the option to save the match confidence in output dataframe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ All of these options can be sent as arguments to `fpd.fuzzy_merge`.
 * **ignore_titles** : bool, default `False`
         - Ignore a predefined list of name titles (such as Mr, Ms, etc)
 * **join** : { 'inner', 'left-outer', 'right-outer', 'full-outer' }
-* **keep_degree** : bool, default `False`
-	- Keep the match confindence in output dataframe in `degree` column
+* **keep_degree** : bool, default `False` - Keep the match confindence in output dataframe stored in `degree` column
 
 For more how-to information, check out [the examples folder](https://github.com/jsoma/fuzzy_pandas/tree/master/examples) or the [the original repo](https://github.com/maxharlow/csvmatch).

--- a/README.md
+++ b/README.md
@@ -110,5 +110,7 @@ All of these options can be sent as arguments to `fpd.fuzzy_merge`.
 * **ignore_titles** : bool, default `False`
         - Ignore a predefined list of name titles (such as Mr, Ms, etc)
 * **join** : { 'inner', 'left-outer', 'right-outer', 'full-outer' }
+* **keep_degree** : bool, default `False`
+	- Keep the match confindence in output dataframe in `degree` column
 
 For more how-to information, check out [the examples folder](https://github.com/jsoma/fuzzy_pandas/tree/master/examples) or the [the original repo](https://github.com/maxharlow/csvmatch).

--- a/fuzzy_pandas/fuzzy_merge.py
+++ b/fuzzy_pandas/fuzzy_merge.py
@@ -12,6 +12,7 @@ def fuzzy_merge(df1,
           keep_right='all',
           method='exact',
           threshold=0.6,
+          keep_degree=False,
           **kwargs):
     """Fuzzy matching between two dataframes
 
@@ -110,11 +111,14 @@ def fuzzy_merge(df1,
 
     if isinstance(keep_right, str):
         keep_right = [keep_right]
-
+    
     output = []
     output.extend(['1.' + col for col in (keep_left or left_on)])
     output.extend(['2.' + col for col in (keep_right or right_on)])
-
+    
+    if keep_degree:
+        output.append('degree')
+    
     if not isinstance(method, list):
         method = [method]
 

--- a/fuzzy_pandas/fuzzy_merge.py
+++ b/fuzzy_pandas/fuzzy_merge.py
@@ -67,7 +67,9 @@ def fuzzy_merge(df1,
     ignore_titles : bool, default False
         Ignore a predefined list of name titles (such as Mr, Ms, etc)
     join : { 'inner', 'left-outer', 'right-outer', 'full-outer' }
-
+    keep_degree : bool, default False
+        Keep the record of match confindence in a separate column named degree
+    
     Returns
     -------
     pd.DataFrame


### PR DESCRIPTION
 I needed to also store the degree of the merge. Couldn't find a way to do it. The keep_left and keep_right options were conflicting with the output parameter if I tried to directly pass it as one of the parameters. So added a simple keep_degree parameter which if passed True will add the `degree` to the output list. I'm not sure even if its useful or not, or was it left out for a reason or if there already is some way to do it. 